### PR TITLE
Pass chat model arguments to Jupyternaut

### DIFF
--- a/packages/jupyter-ai/jupyter_ai/config_manager.py
+++ b/packages/jupyter-ai/jupyter_ai/config_manager.py
@@ -355,21 +355,22 @@ class ConfigManager(Configurable):
         return config.model_provider_id
 
     @property
-    def chat_model_params(self) -> dict[str, Any]:
-        return self._provider_params("model_provider_id", self._lm_providers)
-
-    def _provider_params(
-        self, provider_id_attr: str, providers: dict
-    ) -> dict[str, Any]:
+    def chat_model_args(self) -> dict[str, Any]:
         """
-        Returns the parameters for the provider specified by the given attribute.
+        Returns the model arguments for the current chat model configured by the
+        user.
+
+        If the current chat model is `None`, this returns an empty dictionary.
+        Otherwise, it returns the model arguments set in the dictionary at 
+        `.fields.<chat-model-id>`.
         """
         config = self._read_config()
-        provider_id = getattr(config, provider_id_attr, None)
-        if not provider_id or provider_id not in providers:
+        model_id = config.model_provider_id
+        if not model_id:
             return {}
-        return providers[provider_id].get("params", {})
-        return self._provider_params("model_provider_id", self._lm_providers)
+
+        model_args = config.fields.get(model_id, {})
+        return model_args
 
     @property
     def embedding_model(self) -> str | None:
@@ -400,3 +401,4 @@ class ConfigManager(Configurable):
     def delete_api_key(self, key_name: str):
         # TODO: store in .env files
         pass
+

--- a/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
+++ b/packages/jupyter-ai/jupyter_ai/personas/jupyternaut/jupyternaut.py
@@ -37,8 +37,10 @@ class JupyternautPersona(BasePersona):
             return
 
         model_id = self.config_manager.chat_model
+        model_args = self.config_manager.chat_model_args
         context_as_messages = self.get_context_as_messages(model_id, message)
         response_aiter = await acompletion(
+            **model_args,
             model=model_id,
             messages=[
                 *context_as_messages,


### PR DESCRIPTION
## Description

- Implements the logic required to pass the chat model arguments to Jupyternaut.
- @jonahjung22 You may want to hold off on merging this until you can see the existing model parameters in the UI, since it could be tricky to debug without being able to see/update the model parameters. But this is up to you.